### PR TITLE
[bitnami/mongodb]-Add-securityContext-to-initContainer-dns-check

### DIFF
--- a/bitnami/apache/CHANGELOG.md
+++ b/bitnami/apache/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.14 (2024-08-15)
+## 11.2.15 (2024-08-26)
 
-* [bitnami/apache] fix CrashLoopBackOff when using cloneHtdocsFromGit ([#28868](https://github.com/bitnami/charts/pull/28868))
+* [bitnami/apache] Release 11.2.15 ([#29023](https://github.com/bitnami/charts/pull/29023))
+
+## <small>11.2.14 (2024-08-16)</small>
+
+* [bitnami/apache] fix CrashLoopBackOff when using cloneHtdocsFromGit (#28868) ([b535fa4](https://github.com/bitnami/charts/commit/b535fa4d875858dee6b5f5be35b76be9e3bd897e)), closes [#28868](https://github.com/bitnami/charts/issues/28868)
 
 ## <small>11.2.13 (2024-07-25)</small>
 

--- a/bitnami/apache/Chart.lock
+++ b/bitnami/apache/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 2.20.5
-digest: sha256:5b98791747a148b9d4956b81bb8635f49a0ae831869d700d52e514b8fd1a2445
-generated: "2024-07-17T20:06:08.117648123Z"
+  version: 2.22.0
+digest: sha256:a8fb2fc887ead658a89598a48acde5324196fbc0509503a3eaed50a710fbfe74
+generated: "2024-08-26T14:01:24.131747306Z"

--- a/bitnami/apache/Chart.yaml
+++ b/bitnami/apache/Chart.yaml
@@ -6,11 +6,11 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: apache
-      image: docker.io/bitnami/apache:2.4.62-debian-12-r3
+      image: docker.io/bitnami/apache:2.4.62-debian-12-r5
     - name: apache-exporter
-      image: docker.io/bitnami/apache-exporter:1.0.8-debian-12-r6
+      image: docker.io/bitnami/apache-exporter:1.0.8-debian-12-r7
     - name: git
-      image: docker.io/bitnami/git:2.45.2-debian-12-r7
+      image: docker.io/bitnami/git:2.46.0-debian-12-r0
 apiVersion: v2
 appVersion: 2.4.62
 dependencies:
@@ -35,4 +35,4 @@ maintainers:
 name: apache
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/apache
-version: 11.2.14
+version: 11.2.15

--- a/bitnami/apache/values.yaml
+++ b/bitnami/apache/values.yaml
@@ -64,7 +64,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/apache
-  tag: 2.4.62-debian-12-r3
+  tag: 2.4.62-debian-12-r5
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -94,7 +94,7 @@ image:
 git:
   registry: docker.io
   repository: bitnami/git
-  tag: 2.45.2-debian-12-r7
+  tag: 2.46.0-debian-12-r0
   digest: ""
   pullPolicy: IfNotPresent
   ## Optionally specify an array of imagePullSecrets.
@@ -685,7 +685,7 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/apache-exporter
-    tag: 1.0.8-debian-12-r6
+    tag: 1.0.8-debian-12-r7
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.

--- a/bitnami/tomcat/CHANGELOG.md
+++ b/bitnami/tomcat/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 11.2.17 (2024-08-22)
+## 11.2.18 (2024-08-26)
 
-* [bitnami/tomcat] Release 11.2.17 ([#28982](https://github.com/bitnami/charts/pull/28982))
+* [bitnami/tomcat] Release 11.2.18 ([#29024](https://github.com/bitnami/charts/pull/29024))
+
+## <small>11.2.17 (2024-08-22)</small>
+
+* [bitnami/tomcat] Release 11.2.17 (#28982) ([73aba0b](https://github.com/bitnami/charts/commit/73aba0b224393ef425ca92aebbe46235904016ba)), closes [#28982](https://github.com/bitnami/charts/issues/28982)
 
 ## <small>11.2.16 (2024-08-07)</small>
 

--- a/bitnami/tomcat/Chart.yaml
+++ b/bitnami/tomcat/Chart.yaml
@@ -6,11 +6,11 @@ annotations:
   licenses: Apache-2.0
   images: |
     - name: jmx-exporter
-      image: docker.io/bitnami/jmx-exporter:1.0.1-debian-12-r5
+      image: docker.io/bitnami/jmx-exporter:1.0.1-debian-12-r6
     - name: os-shell
-      image: docker.io/bitnami/os-shell:12-debian-12-r27
+      image: docker.io/bitnami/os-shell:12-debian-12-r28
     - name: tomcat
-      image: docker.io/bitnami/tomcat:10.1.28-debian-12-r2
+      image: docker.io/bitnami/tomcat:10.1.28-debian-12-r3
 apiVersion: v2
 appVersion: 10.1.28
 dependencies:
@@ -35,4 +35,4 @@ maintainers:
 name: tomcat
 sources:
 - https://github.com/bitnami/charts/tree/main/bitnami/tomcat
-version: 11.2.17
+version: 11.2.18

--- a/bitnami/tomcat/values.yaml
+++ b/bitnami/tomcat/values.yaml
@@ -70,7 +70,7 @@ extraDeploy: []
 image:
   registry: docker.io
   repository: bitnami/tomcat
-  tag: 10.1.28-debian-12-r2
+  tag: 10.1.28-debian-12-r3
   digest: ""
   ## Specify a imagePullPolicy
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
@@ -680,7 +680,7 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/os-shell
-    tag: 12-debian-12-r27
+    tag: 12-debian-12-r28
     digest: ""
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
@@ -738,7 +738,7 @@ metrics:
     image:
       registry: docker.io
       repository: bitnami/jmx-exporter
-      tag: 1.0.1-debian-12-r5
+      tag: 1.0.1-debian-12-r6
       digest: ""
       ## Specify a imagePullPolicy
       ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

 If the containerSecurityContext is enabled, it adds securityContext to the initContainer dns-check which is missing

### Benefits

The initContainer has securityContext like the log-dir initContainer.

### Possible drawbacks

-

### Applicable issues


### Additional information


### Checklist

- [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [ ] Variables are documented in the values.yaml and added to the `README.md` using [readme-generator-for-helm](https://github.com/bitnami/readme-generator-for-helm)
- [X ] Title of the pull request follows this pattern [bitnami/<name_of_the_chart>] Descriptive title
- [X ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/bitnami/charts/blob/main/CONTRIBUTING.md#sign-your-work)
